### PR TITLE
Update collins_client and drop ruby 1.9 support

### DIFF
--- a/collins_auth.gemspec
+++ b/collins_auth.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "collins_auth"
-  s.version = "0.1.2"
+  s.version = "0.2.0"
   s.date = "2014-07-08"
   s.summary = "Library to aid in getting an authenticated Collins::Client"
   s.description = "This is a library to make it easy to obtain an authenticated collins_client object. It attempts to load credentials from the following yaml files ENV['COLLINS_CLIENT_CONFIG'], ~/.collins.yml, /etc/collins.yml, /var/db/collins.yml, and supports user input."
@@ -11,6 +11,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{lib}/*.rb", "*.md", "*.txt"]
 
-  s.add_dependency 'collins_client'
+  s.required_ruby_version = '>= 2.0.0'
+
+  s.add_dependency 'collins_client', '~> 0.3.0'
   s.add_dependency 'highline'
 end

--- a/collins_auth.gemspec
+++ b/collins_auth.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.description = "This is a library to make it easy to obtain an authenticated collins_client object. It attempts to load credentials from the following yaml files ENV['COLLINS_CLIENT_CONFIG'], ~/.collins.yml, /etc/collins.yml, /var/db/collins.yml, and supports user input."
   s.authors = ["Michael Benedict"]
   s.email = "benedict@tumblr.com"
-  s.license = "Apache License 2.0"
+  s.license = "Apache-2.0"
   s.homepage = "https://github.com/tumblr/collins_auth"
 
   s.files = Dir["{lib}/*.rb", "*.md", "*.txt"]


### PR DESCRIPTION
In https://github.com/tumblr/collins_client/pull/2 we'd like to update the `httparty` dependency and are dropping support for ruby 1.9 in `collins_client`.

This pulls the new gem in to `collins_auth` and fixes the short identifier of the license in the gemspec.

@tumblr/collins 