### PR TITLE
add warning for when host does not have protocol specified

### DIFF
--- a/collins_auth.gemspec
+++ b/collins_auth.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "collins_auth"
-  s.version = "0.2.0"
+  s.version = "0.2.1"
   s.date = "2014-07-08"
   s.summary = "Library to aid in getting an authenticated Collins::Client"
   s.description = "This is a library to make it easy to obtain an authenticated collins_client object. It attempts to load credentials from the following yaml files ENV['COLLINS_CLIENT_CONFIG'], ~/.collins.yml, /etc/collins.yml, /var/db/collins.yml, and supports user input."

--- a/lib/collins_auth.rb
+++ b/lib/collins_auth.rb
@@ -15,9 +15,12 @@ module Collins
 
     def self.load_config(options = {})
       conf = (options[:prompt] == :only) ? {} : (read_config(options[:config_file]) || {}).merge(options)
-
+      # check if host doesn't have a protocol specified
+      if conf.key?(:host) && !conf[:host].nil? && conf[:host].match(/^(http|https)\:\/\/.+/).nil?
+        raise "host #{conf[:host]} has no protocol specified. please specify http:// or https://"
+      end
       # check if we have all that we expect
-      if [:username, :password, :host].all? {|key| conf.keys.include? key}
+      if [:username, :password, :host].all? { |key| conf.key? key }
         return conf
       end
 


### PR DESCRIPTION
prevents dullards like me from constantly doing:
`host: collins.somedomain.net` and wondering why i get errors like `Cannot assign requested address - Exception talking to /api/assets: Failed to open TCP connection to :80 (Cannot assign requested address - connect(2) for nil port 80)` or ```Exception talking to /api/assets: undefined method `map' for nil:NilClass``` or `that's my only liver please i need that`